### PR TITLE
Fix repo cleanup variable reference

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -76,6 +76,7 @@ async def analyze_repo(request: RepoRequest, background_tasks: BackgroundTasks):
 
 async def process_repo(repo_id: str, url: str, branch: str):
     """Process repository in background."""
+    repo_path = None
     try:
         # Clone repository
         repo_path = await repo_analyzer.clone_repository(url, branch)


### PR DESCRIPTION
## Summary
- initialize `repo_path` variable before try block in `process_repo`
  to avoid `UnboundLocalError` during cleanup when cloning fails

## Testing
- `python -m py_compile backend/app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684d500bb5e083218c43f2018c84402a